### PR TITLE
Feat #76 dev용 docker compose작성

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  mysql-main-dev:
+    image: mysql:8.0
+    container_name: travel-role-mysql-main
+    ports:
+      - 13306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+      TZ: Asia/Seoul
+      MYSQL_DATABASE: travel
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+  mysql-test-dev:
+    image: mysql:8.0
+    container_name: travel-role-mysql-test
+    ports:
+      - 13309:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+      TZ: Asia/Seoul
+      MYSQL_DATABASE: test
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/test?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost:13306/travel?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
     username: root
-    password: ENC(7udf7PA9ds8l4ejCbNfMkA==)
+    password: test
 
   jpa:
     database: MYSQL

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3309/test?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost:13309/test?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
     username: root
     password: test
 


### PR DESCRIPTION
### 구현목록
- mysql의 localhost 비밀번호가 각각다르고, 새로운 개발 환경에서 구축하기 귀찮을 수 있으므로, `docker-compose.yml` 파일 작성함
- 실행방법은, notion에 작성해둠
### 실행방법 
<img width="751" alt="image" src="https://user-images.githubusercontent.com/74089271/234501277-d1602804-1f78-48a6-b3d3-df46aec725c2.png">

