### PR TITLE
Hotfix: 방정보 가져오는 로직 오류

### DIFF
--- a/src/main/java/com/travel/role/domain/room/dao/RoomQuerydslImpl.java
+++ b/src/main/java/com/travel/role/domain/room/dao/RoomQuerydslImpl.java
@@ -37,7 +37,6 @@ public class RoomQuerydslImpl implements RoomQuerydsl {
 					.join(findParticipant.room, room)
 					.join(findParticipant.user, user)
 					.where(user.email.eq(email))
-			)).orderBy(room.createDate.desc())
-			.fetch();
+			)).fetch();
 	}
 }

--- a/src/main/java/com/travel/role/domain/room/service/RoomService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomService.java
@@ -53,6 +53,17 @@ public class RoomService {
         List<Tuple> findRoomInfo = roomRepository.getMemberInRoom(userPrincipal.getEmail());
 
         Map<Long, RoomResponseDTO> hash = new HashMap<>();
+		for (Tuple tuple : findRoomInfo) {
+			Room room = tuple.get(0, Room.class);
+			User user = tuple.get(1, User.class);
+
+			if (Objects.equals(user.getEmail(), userPrincipal.getEmail())) {
+				List<MemberDTO> members = new ArrayList<>();
+				members.add(new MemberDTO(user.getName(), user.getProfile()));
+				hash.put(room.getId(), RoomResponseDTO.of(room, members));
+			}
+		}
+
         for (Tuple tuple : findRoomInfo) {
             Room room = tuple.get(0, Room.class);
             User user = tuple.get(1, User.class);
@@ -61,12 +72,7 @@ public class RoomService {
                 RoomResponseDTO roomResponseDTO = hash.get(room.getId());
                 roomResponseDTO.getMembers().add(new MemberDTO(user.getName(), user.getProfile()));
                 hash.put(room.getId(), roomResponseDTO);
-            } else if (Objects.equals(user.getEmail(), userPrincipal.getEmail())) {
-				List<MemberDTO> members = new ArrayList<>();
-				members.add(new MemberDTO(user.getName(), user.getProfile()));
-
-				hash.put(room.getId(), RoomResponseDTO.of(room, members));
-			}
+            }
         }
 
         return new ArrayList<>(hash.values());

--- a/src/main/java/com/travel/role/domain/room/service/RoomService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomService.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,12 +61,12 @@ public class RoomService {
                 RoomResponseDTO roomResponseDTO = hash.get(room.getId());
                 roomResponseDTO.getMembers().add(new MemberDTO(user.getName(), user.getProfile()));
                 hash.put(room.getId(), roomResponseDTO);
-            } else {
-                List<MemberDTO> members = new ArrayList<>();
-                members.add(new MemberDTO(user.getName(), user.getProfile()));
+            } else if (Objects.equals(user.getEmail(), userPrincipal.getEmail())) {
+				List<MemberDTO> members = new ArrayList<>();
+				members.add(new MemberDTO(user.getName(), user.getProfile()));
 
-                hash.put(room.getId(), RoomResponseDTO.of(room, members));
-            }
+				hash.put(room.getId(), RoomResponseDTO.of(room, members));
+			}
         }
 
         return new ArrayList<>(hash.values());

--- a/src/test/java/com/travel/role/domain/room/RoomTest.java
+++ b/src/test/java/com/travel/role/domain/room/RoomTest.java
@@ -103,15 +103,14 @@ class RoomTest {
     @Test
     void 방의_정보를_제대로_불러오는지() {
         // given
-        UserPrincipal userPrincipal = new UserPrincipal(1L, "haechan@naver.com", "1234", null);
+        UserPrincipal userPrincipal = new UserPrincipal(1L, "ChanYoo@naver.com", "1234", null);
 
         // when
         List<RoomResponseDTO> roomList = roomService.getRoomList(userPrincipal);
 
         // then
+        assertThat(roomList.size()).isEqualTo(1);
         assertThat(roomList.get(0).getRoomName()).isEqualTo("room1");
         assertThat(roomList.get(0).getMembers().size()).isEqualTo(3);
-        assertThat(roomList.get(1).getRoomName()).isEqualTo("room2");
-        assertThat(roomList.get(1).getMembers().size()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
### 오류 현황
- 방의 리스트를 불러오는 로직에서, 해당 회원의 방만 저장을 해야하는데, 다른 회원의 방정보도 저장함
- 로직을 기존 roomId 저장 -> 해당하는 member 저장방식에서, 해당하는 회원의 room id를 for문으로 돌며 확인한 뒤, for문으로 해당하는 유저의 정보를 넣었음

### 고민사항
- 현재는 해당 유저의 방에 있는 모든 유저가 나오는 쿼리를 짜서, 다음과 같이 2N만큼 반목문을 돌게하여 유저의 정보를 저장함
    - 고민이 되는게, 결국 O(N)이라도 반복문을 2번도는게 효율적인 방식인거는 모르겠음
- 생각하는 방향은 차라리, 유저가 속하는 방의정보를 보여주는 쿼리 1 / 유저의 방에 참여하고 있는 회원의 정보 쿼리2 로 나눠서할지 고민

-> 우선 다음과 같이 반영한뒤, 이후에 데이터가 많아지거나 성능테스트에 갔을때, 2개의 방법을 고민해보면 좋을것 같음