### PR TITLE
Refactor: UserReadService에서 오버로딩 메서드 변경

### DIFF
--- a/src/main/java/com/travel/role/domain/room/controller/RoomController.java
+++ b/src/main/java/com/travel/role/domain/room/controller/RoomController.java
@@ -30,30 +30,30 @@ public class RoomController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping("/room")
 	public void makeRoom(@AuthenticationPrincipal UserPrincipal userPrincipal,@RequestBody MakeRoomRequestDTO dto) {
-		roomService.makeRoom(userPrincipal, dto);
+		roomService.makeRoom(userPrincipal.getEmail(), dto);
 	}
 
 	@GetMapping("/room")
 	public List<RoomResponseDTO> getRoomList(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-		return roomService.getRoomList(userPrincipal);
+		return roomService.getRoomList(userPrincipal.getEmail());
 	}
 
 	@GetMapping("/room/invite-code/{room_id}")
 	public String getInviteCode(@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable("room_id") Long roomId) {
-		return roomService.makeInviteCode(userPrincipal, roomId);
+		return roomService.makeInviteCode(userPrincipal.getEmail(), roomId);
 	}
 
 	@GetMapping("/check-room/{invite_code}")
 	public void checkRoomInviteCode(@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable("invite_code") String inviteCode) {
-		roomService.checkRoomInviteCode(userPrincipal, inviteCode);
+		roomService.checkRoomInviteCode(userPrincipal.getEmail(), inviteCode);
 	}
 
 	@PostMapping("/room/{invite_code}")
 	@ResponseStatus(HttpStatus.CREATED)
 	public InviteResponseDTO inviteUser(@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable("invite_code") String inviteCode, @RequestBody List<String> roles) {
-		return roomService.inviteUser(userPrincipal, inviteCode, roles);
+		return roomService.inviteUser(userPrincipal.getEmail(), inviteCode, roles);
 	}
 }

--- a/src/main/java/com/travel/role/domain/user/service/UserReadService.java
+++ b/src/main/java/com/travel/role/domain/user/service/UserReadService.java
@@ -5,7 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.travel.role.domain.user.entity.User;
 import com.travel.role.domain.user.repository.UserRepository;
-import com.travel.role.global.auth.token.UserPrincipal;
 import com.travel.role.global.exception.user.UserInfoNotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -20,12 +19,6 @@ public class UserReadService {
 	public User findUserByEmailOrElseThrow(String email) {
 
 		return userRepository.findByEmail(email)
-			.orElseThrow(UserInfoNotFoundException::new);
-	}
-
-	//TODO: 이후 userprincipal이 아닌 email로 변경
-	public User findUserByEmailOrElseThrow(UserPrincipal userPrincipal) {
-		return userRepository.findByEmail(userPrincipal.getEmail())
 			.orElseThrow(UserInfoNotFoundException::new);
 	}
 }

--- a/src/main/java/com/travel/role/domain/wantplace/controller/WantPlaceController.java
+++ b/src/main/java/com/travel/role/domain/wantplace/controller/WantPlaceController.java
@@ -1,16 +1,23 @@
 package com.travel.role.domain.wantplace.controller;
 
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.travel.role.domain.wantplace.dto.request.WantPlaceRequestDTO;
 import com.travel.role.domain.wantplace.dto.response.WantPlaceResponseDTO;
 import com.travel.role.domain.wantplace.service.WantPlaceService;
 import com.travel.role.global.auth.token.UserPrincipal;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,17 +27,17 @@ public class WantPlaceController {
 
     @GetMapping("/want-place")
     public ResponseEntity<WantPlaceResponseDTO> getPlaceList(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestParam("roomId") Long roomId) {
-        WantPlaceResponseDTO wantPlaceResponseDTOS = wantPlaceService.getWantPlaceList(userPrincipal, roomId);
+        WantPlaceResponseDTO wantPlaceResponseDTOS = wantPlaceService.getWantPlaceList(userPrincipal.getEmail(), roomId);
         return ResponseEntity.ok(wantPlaceResponseDTOS);
     }
 
     @PostMapping("/want-place")
     public void addWantPlace(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestBody @Valid WantPlaceRequestDTO wantPlaceRequestDTO) {
-        wantPlaceService.addWantPlace(userPrincipal, wantPlaceRequestDTO);
+        wantPlaceService.addWantPlace(userPrincipal.getEmail(), wantPlaceRequestDTO);
     }
 
     @DeleteMapping("/want-place")
     public void deleteWantPlace(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestParam("roomId") Long roomId, @RequestParam("placeId") Long placeId) {
-        wantPlaceService.deleteWantPlace(userPrincipal, roomId, placeId);
+        wantPlaceService.deleteWantPlace(userPrincipal.getEmail(), roomId, placeId);
     }
 }

--- a/src/main/java/com/travel/role/domain/wantplace/service/WantPlaceService.java
+++ b/src/main/java/com/travel/role/domain/wantplace/service/WantPlaceService.java
@@ -20,7 +20,6 @@ import com.travel.role.domain.wantplace.dto.response.WantPlaceDTO;
 import com.travel.role.domain.wantplace.dto.response.WantPlaceResponseDTO;
 import com.travel.role.domain.wantplace.entity.WantPlace;
 import com.travel.role.domain.wantplace.repository.WantPlaceRepository;
-import com.travel.role.global.auth.token.UserPrincipal;
 import com.travel.role.global.exception.user.PlaceInfoNotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -35,23 +34,23 @@ public class WantPlaceService {
 	private final RoomParticipantReadService roomParticipantReadService;
 	private final ParticipantRoleRepository participantRoleRepository;
 
-	public void deleteWantPlace(UserPrincipal userPrincipal, Long roomId, Long placeId) {
-		User user = userReadService.findUserByEmailOrElseThrow(userPrincipal);
+	public void deleteWantPlace(String email, Long roomId, Long placeId) {
+		User user = userReadService.findUserByEmailOrElseThrow(email);
 		Room room = roomReadService.findRoomByIdOrElseThrow(roomId);
 		roomParticipantReadService.checkParticipant(user, room);
 		deleteWantPlaceById(placeId);
 	}
 
-	public WantPlaceResponseDTO getWantPlaceList(UserPrincipal userPrincipal, Long roomId) {
-		User user = userReadService.findUserByEmailOrElseThrow(userPrincipal);
+	public WantPlaceResponseDTO getWantPlaceList(String email, Long roomId) {
+		User user = userReadService.findUserByEmailOrElseThrow(email);
 		Room room = roomReadService.findRoomByIdOrElseThrow(roomId);
 		roomParticipantReadService.checkParticipant(user, room);
 		List<WantPlaceDTO> wantPlaceDTOS = getWantPlaceList(roomId);
 		return WantPlaceResponseDTO.of(wantPlaceDTOS, checkRole(user, room));
 	}
 
-	public void addWantPlace(UserPrincipal userPrincipal, WantPlaceRequestDTO wantPlaceRequestDTO) {
-		User user = userReadService.findUserByEmailOrElseThrow(userPrincipal);
+	public void addWantPlace(String email, WantPlaceRequestDTO wantPlaceRequestDTO) {
+		User user = userReadService.findUserByEmailOrElseThrow(email);
 		Room room = roomReadService.findRoomByIdOrElseThrow(wantPlaceRequestDTO.getRoomId());
 		roomParticipantReadService.checkParticipant(user, room);
 		wantPlaceRepository.save(WantPlace.of(room, wantPlaceRequestDTO));

--- a/src/test/java/com/travel/role/integration/room/RoomTest.java
+++ b/src/test/java/com/travel/role/integration/room/RoomTest.java
@@ -22,7 +22,6 @@ import com.travel.role.domain.room.service.RoomService;
 import com.travel.role.domain.user.dto.auth.SignUpRequestDTO;
 import com.travel.role.domain.user.entity.User;
 import com.travel.role.domain.user.repository.UserRepository;
-import com.travel.role.global.auth.token.UserPrincipal;
 
 @SpringBootTest
 @Transactional
@@ -99,10 +98,9 @@ class RoomTest {
     @Test
     void 방의_정보를_제대로_불러오는지() {
         // given
-        UserPrincipal userPrincipal = new UserPrincipal(1L, "ChanYoo@naver.com", "1234", null);
-
+        String email = "ChanYoo@naver.com";
         // when
-        List<RoomResponseDTO> roomList = roomService.getRoomList(userPrincipal);
+        List<RoomResponseDTO> roomList = roomService.getRoomList(email);
 
         // then
         assertThat(roomList.size()).isEqualTo(1);

--- a/src/test/java/com/travel/role/unit/room/service/RoomServiceTest.java
+++ b/src/test/java/com/travel/role/unit/room/service/RoomServiceTest.java
@@ -77,7 +77,7 @@ class RoomServiceTest {
 			.willReturn("1234");
 		given(participantRoleRepository.existsByUserAndRoomAndRoomRoleIn(any(User.class), any(Room.class), anyList()))
 			.willReturn(true);
-		given(userReadService.findUserByEmailOrElseThrow(any(UserPrincipal.class)))
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
 			.willReturn(User.builder().build());
 		given(roomReadService.findRoomByIdOrElseThrow(anyLong()))
 			.willReturn(new Room(1L, "강릉으로떠나요", LocalDate.now(), LocalDate.now().plusDays(1L),
@@ -85,7 +85,7 @@ class RoomServiceTest {
 				, null));
 
 		//when
-		String inviteCode = roomService.makeInviteCode(makeUserPrincipal(), 1L);
+		String inviteCode = roomService.makeInviteCode("haechan@naver.com", 1L);
 
 		//then
 		assertThat(inviteCode).isEqualTo("1234");
@@ -98,13 +98,13 @@ class RoomServiceTest {
 			.willReturn("1234");
 		given(participantRoleRepository.existsByUserAndRoomAndRoomRoleIn(any(User.class), any(Room.class), anyList()))
 			.willReturn(true);
-		given(userReadService.findUserByEmailOrElseThrow(any(UserPrincipal.class)))
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
 			.willReturn(User.builder().build());
 		given(roomReadService.findRoomByIdOrElseThrow(anyLong()))
 			.willReturn(makeRoom());
 
 		//when
-		String inviteCode = roomService.makeInviteCode(makeUserPrincipal(), 1L);
+		String inviteCode = roomService.makeInviteCode("haechan@naver.com", 1L);
 
 		//then
 		assertThat(inviteCode).isEqualTo("1234");
@@ -117,7 +117,7 @@ class RoomServiceTest {
 			.willReturn(makeInvalidInviteDateRoom());
 
 		//when,then
-		assertThatThrownBy(() -> {roomService.checkRoomInviteCode(makeUserPrincipal(), "1234");})
+		assertThatThrownBy(() -> {roomService.checkRoomInviteCode("haechan@naver.com", "1234");})
 			.isInstanceOf(InvalidInviteCode.class);
 	}
 
@@ -126,13 +126,13 @@ class RoomServiceTest {
 		//given
 		given(roomReadService.getRoomUsingInviteCode(anyString()))
 			.willReturn(makeRoom());
-		given(userReadService.findUserByEmailOrElseThrow(any(UserPrincipal.class)))
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
 			.willReturn(makeUser());
 		given(roomRepository.existsUserInRoom(anyString(), anyLong()))
 			.willReturn(false);
 
 		//when, then
-		assertThatThrownBy(() -> {roomService.inviteUser(makeUserPrincipal(), "1234", List.of("ADMIN"));})
+		assertThatThrownBy(() -> {roomService.inviteUser("haechan@naver.com", "1234", List.of("ADMIN"));})
 			.isInstanceOf(UserHaveNotPrivilegeException.class);
 	}
 
@@ -141,13 +141,13 @@ class RoomServiceTest {
 		//given
 		given(roomReadService.getRoomUsingInviteCode(anyString()))
 			.willReturn(makeRoom());
-		given(userReadService.findUserByEmailOrElseThrow(any(UserPrincipal.class)))
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
 			.willReturn(makeUser());
 		given(roomRepository.existsUserInRoom(anyString(), anyLong()))
 			.willReturn(false);
 
 		//when, thend .
-		assertThatThrownBy(() -> {roomService.inviteUser(makeUserPrincipal(), "1234", List.of("HAECHAN"));})
+		assertThatThrownBy(() -> {roomService.inviteUser("haechan@naver.com", "1234", List.of("HAECHAN"));})
 			.isInstanceOf(UserHaveNotPrivilegeException.class);
 	}
 	private static UserPrincipal makeUserPrincipal() {
@@ -210,7 +210,7 @@ class RoomServiceTest {
 
 			WantPlace wantPlace = WantPlace.of(room, getWantPlaceRequestDto());
 
-			given(userReadService.findUserByEmailOrElseThrow(any(UserPrincipal.class)))
+			given(userReadService.findUserByEmailOrElseThrow(anyString()))
 					.willReturn(user2);
 			given(roomReadService.findRoomByIdOrElseThrow(anyLong()))
 					.willReturn(room);
@@ -218,7 +218,7 @@ class RoomServiceTest {
 				.when(roomParticipantReadService).checkParticipant(any(User.class), any(Room.class));
 
 			// when
-			wantPlaceService.addWantPlace(makeUserPrincipal(), getWantPlaceRequestDto());
+			wantPlaceService.addWantPlace("asdd@gmail.com", getWantPlaceRequestDto());
 
 			// then
 			assertThat(wantPlace.getPlaceName()).isEqualTo("제주도");
@@ -231,12 +231,8 @@ class RoomServiceTest {
 
 		private static WantPlaceRequestDTO getWantPlaceRequestDto() {
 			return new WantPlaceRequestDTO(
-					1L, "제주도", "제주도", "1234",
-					123.0, 456.0);
-		}
-
-		private static UserPrincipal makeUserPrincipal() {
-			return new UserPrincipal(1L, "asdd@gmail.com", "1234", null);
+				1L, "제주도", "제주도", "1234",
+				123.0, 456.0);
 		}
 	}
 }


### PR DESCRIPTION
### 구현 목록
- `UserPrincipal`을 받던 메서드 모두 `email`을 받도록 수정함
### 의견
- 유저가 방에 참여하고있는지를 판단하는 메서드는 `roomPatricipantRepository`에 `existsByUserAndRoom`으로 판단하는것으로 통일하자고 했습니다. 
- 제가 작성한 코드는 다음 사진과 같습니다. 
<img width="603" alt="image" src="https://user-images.githubusercontent.com/74089271/235040289-c93b77c0-0bf6-4eb9-a5c7-208117090af8.png">
- 하지만 `existsByUserAndRoom`은 `User`의 정보를 가져오기 위해서, `User` 정보를 받아오는 쿼리를 사용한 뒤, `existsUserInRoom`에 대한 쿼리를 날려야합니다. -> 즉 기존보다 1개의 쿼리를 더 날려아합니다. 

이런 상황에서 그냥 `roomParticipantRepository`에 정의된 메서드를 그냥 사용하는것이 좋을까요? 의견 부탁드립니다 :) 