### PR TITLE
Hotfix : ProviderId 저장이 누락되어있는 오류 발견

### DIFF
--- a/src/main/java/com/travel/role/global/auth/entity/AuthInfo.java
+++ b/src/main/java/com/travel/role/global/auth/entity/AuthInfo.java
@@ -55,6 +55,10 @@ public class AuthInfo {
 		return new AuthInfo(null, provider, null, null, null, Role.USER, user);
 	}
 
+	public static AuthInfo of(Provider provider, String providerId, User user) {
+		return new AuthInfo(null, provider, providerId, null, null, Role.USER, user);
+	}
+
 	public void updateRefreshToken(final String refreshToken) {
 		this.refreshToken = refreshToken;
 	}

--- a/src/main/java/com/travel/role/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/travel/role/global/auth/service/CustomOAuth2UserService.java
@@ -77,7 +77,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		User user = User.of(userInfo);
 		user = userRepository.save(user);
 
-		AuthInfo authInfo = AuthInfo.of(provider, user);
+		String providerId = userInfo.getId();
+		AuthInfo authInfo = AuthInfo.of(provider, providerId, user);
 		return authRepository.save(authInfo);
 	}
 


### PR DESCRIPTION
### 문제 발생 상황
- Auth 리팩터링 이후, provider Id를 저장하는 로직에 문제 발견, providerId를 저장하지 않는 오류 발생 
### 테스트 코드 
<img width="573" alt="image" src="https://user-images.githubusercontent.com/74089271/236223630-da9aae25-9f82-4258-bd61-f7f77433cb9e.png">
