### PR TITLE
Feat #169 해당 유저의 역할 정보를 가져오는 API 작성

### DIFF
--- a/src/main/java/com/travel/role/domain/room/controller/RoomController.java
+++ b/src/main/java/com/travel/role/domain/room/controller/RoomController.java
@@ -27,6 +27,7 @@ import com.travel.role.domain.room.dto.response.RoomInfoResponseDTO;
 import com.travel.role.domain.room.dto.response.RoomResponseDTO;
 import com.travel.role.domain.room.dto.response.SidebarResponseDTO;
 import com.travel.role.domain.room.dto.response.TimeResponseDTO;
+import com.travel.role.domain.room.entity.RoomRole;
 import com.travel.role.domain.room.service.RoomService;
 import com.travel.role.global.auth.token.UserPrincipal;
 
@@ -114,5 +115,11 @@ public class RoomController {
 	public SidebarResponseDTO getSidebar(@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable("room_id") Long roomId) {
 		return roomService.getSidebar(userPrincipal.getEmail(), roomId);
+	}
+
+	@GetMapping("/room/{room_id}/role")
+	public List<RoomRole> getUserRoles(@AuthenticationPrincipal UserPrincipal userPrincipal,
+		@PathVariable("room_id") Long roomId) {
+		return roomService.getUserRoles(userPrincipal.getEmail(), roomId);
 	}
 }

--- a/src/main/java/com/travel/role/domain/room/service/ParticipantRoleReadService.java
+++ b/src/main/java/com/travel/role/domain/room/service/ParticipantRoleReadService.java
@@ -11,6 +11,7 @@ import com.travel.role.domain.room.entity.Room;
 import com.travel.role.domain.room.entity.RoomRole;
 import com.travel.role.domain.room.repository.ParticipantRoleRepository;
 import com.travel.role.domain.user.entity.User;
+import com.travel.role.global.exception.room.RolesIsEmptyException;
 import com.travel.role.global.exception.room.UserHaveNotPrivilegeException;
 import com.travel.role.global.exception.user.RoomInfoNotFoundException;
 
@@ -45,6 +46,10 @@ public class ParticipantRoleReadService {
 	public List<RoomRole> findRoomRolesByUserAndRoom(User user, Room room) {
 
 		List<ParticipantRole> participantRoles = participantRoleRepository.findByUserAndRoom(user, room);
+
+		if (participantRoles.isEmpty())
+			throw new RolesIsEmptyException();
+
 		return participantRoles.stream().map(ParticipantRole::getRoomRole)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/com/travel/role/domain/room/service/ParticipantRoleReadService.java
+++ b/src/main/java/com/travel/role/domain/room/service/ParticipantRoleReadService.java
@@ -45,7 +45,7 @@ public class ParticipantRoleReadService {
 	public List<RoomRole> findRoomRolesByUserAndRoom(User user, Room room) {
 
 		List<ParticipantRole> participantRoles = participantRoleRepository.findByUserAndRoom(user, room);
-		return participantRoles.stream().map(participantRole -> participantRole.getRoomRole())
+		return participantRoles.stream().map(ParticipantRole::getRoomRole)
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/travel/role/domain/room/service/RoomService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomService.java
@@ -476,4 +476,8 @@ public class RoomService {
 
 		return SidebarResponseDTO.of(room, roles);
 	}
+
+	public List<RoomRole> getUserRoles(String email, Long roomId) {
+		return null;
+	}
 }

--- a/src/main/java/com/travel/role/domain/room/service/RoomService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomService.java
@@ -478,6 +478,10 @@ public class RoomService {
 	}
 
 	public List<RoomRole> getUserRoles(String email, Long roomId) {
-		return null;
+		User user = userReadService.findUserByEmailOrElseThrow(email);
+		Room room = roomReadService.findRoomByIdOrElseThrow(roomId);
+		roomParticipantReadService.checkParticipant(user, room);
+
+		return participantRoleReadService.findRoomRolesByUserAndRoom(user, room);
 	}
 }

--- a/src/main/java/com/travel/role/global/exception/dto/ExceptionMessage.java
+++ b/src/main/java/com/travel/role/global/exception/dto/ExceptionMessage.java
@@ -39,6 +39,7 @@ public final class ExceptionMessage {
 	public static final String LATE_DATE_ERROR = "일정보다 늦은 날짜입니다.";
 	public static final String ADMIN_IS_ONLY_ONE = "총무는 한명만 가능합니다.";
 	public static final String ROOM_NAME_NOT_EMPTY = "방 이름은 필수값 입니다.";
+	public static final String ROLE_IS_EMPTY = "이 방에 해당하는 유저의 역할 정보가 존재하지 않습니다.";
 	// comment
 	public static final String COMMENT_NOT_EMPTY = "댓글 내용은 필수값 입니다.";
 	public static final String COMMENT_NOT_FOUND = "해당하는 댓글이 존재하지 않습니다.";

--- a/src/main/java/com/travel/role/global/exception/room/RolesIsEmptyException.java
+++ b/src/main/java/com/travel/role/global/exception/room/RolesIsEmptyException.java
@@ -1,0 +1,9 @@
+package com.travel.role.global.exception.room;
+
+import static com.travel.role.global.exception.dto.ExceptionMessage.*;
+
+public class RolesIsEmptyException extends RuntimeException{
+	public RolesIsEmptyException() {
+		super(ROLE_IS_EMPTY);
+	}
+}


### PR DESCRIPTION
### 구현목록
- 해당 유저의 역할정보를 가져오는 API 작성
### 테스트 작동
<img width="484" alt="image" src="https://github.com/TravelRole/roleTravel-backend/assets/74089271/4de5675b-279c-42eb-ae89-bba28b371992">
