### PR TITLE
Hotfix Enum및, ConcurrentModificationException 해결

### DIFF
--- a/src/main/java/com/travel/role/domain/room/entity/RoomRole.java
+++ b/src/main/java/com/travel/role/domain/room/entity/RoomRole.java
@@ -2,6 +2,7 @@ package com.travel.role.domain.room.entity;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import lombok.AllArgsConstructor;
@@ -37,5 +38,14 @@ public enum RoomRole {
 	public static List<RoomRole> getReservationRoles() {
 
 		return List.of(RESERVATION, ADMIN);
+	}
+
+	@JsonCreator
+	public static RoomRole from(String roomRole) {
+		try {
+			return RoomRole.valueOf(roomRole.toUpperCase());
+		} catch (NullPointerException | IllegalArgumentException e) {
+			return null;
+		}
 	}
 }

--- a/src/main/java/com/travel/role/domain/room/service/RoomService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomService.java
@@ -271,9 +271,9 @@ public class RoomService {
 
 		List<Long> ids = new ArrayList<>();
 		List<ParticipantRole> participantRoles = participantMap.get(adminEmail);
-		for (ParticipantRole participantRole : participantRoles) {
-			ids.add(participantRole.getId());
-			participantRoles.remove(participantRole);
+		for (int i = 0; i < participantRoles.size() - 1; i++) {
+			ids.add(participantRoles.get(i).getId());
+			participantRoles.remove(participantRoles.get(i));
 		}
 		participantRoleRepository.deleteAllByIdInQuery(ids);
 	}


### PR DESCRIPTION
### 해결내용
- List를 iter로 돌려서, concurrentModificationException이 발생하는 문제 해결
- Enum을 변경할때, Enum에 대해 변경할 수 있는 `@JsonCreator` 생성
### 특이사항
- Enum인 `RoomRole`에 대해서, `Request` 또는 `Response`를 한글로 하기로함 