### PR TITLE
[Refactor] Room Invite 코드 분리

### DIFF
--- a/src/main/java/com/travel/role/domain/room/controller/RoomController.java
+++ b/src/main/java/com/travel/role/domain/room/controller/RoomController.java
@@ -30,6 +30,7 @@ import com.travel.role.domain.room.dto.response.RoomResponseDTO;
 import com.travel.role.domain.room.dto.response.SidebarResponseDTO;
 import com.travel.role.domain.room.dto.response.TimeResponseDTO;
 import com.travel.role.domain.room.entity.RoomRole;
+import com.travel.role.domain.room.service.RoomInviteService;
 import com.travel.role.domain.room.service.RoomService;
 import com.travel.role.global.auth.token.UserPrincipal;
 
@@ -41,6 +42,7 @@ import lombok.RequiredArgsConstructor;
 public class RoomController {
 
 	private final RoomService roomService;
+	private final RoomInviteService roomInviteService;
 
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping("/room")
@@ -56,20 +58,20 @@ public class RoomController {
 	@GetMapping("/room/invite-code/{room_id}")
 	public String getInviteCode(@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable("room_id") Long roomId) {
-		return roomService.makeInviteCode(userPrincipal.getEmail(), roomId);
+		return roomInviteService.makeInviteCode(userPrincipal.getEmail(), roomId);
 	}
 
 	@GetMapping("/check-room/{invite_code}")
 	public void checkRoomInviteCode(@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable("invite_code") String inviteCode) {
-		roomService.checkRoomInviteCode(userPrincipal.getEmail(), inviteCode);
+		roomInviteService.checkRoomInviteCode(userPrincipal.getEmail(), inviteCode);
 	}
 
 	@PostMapping("/room/{invite_code}")
 	@ResponseStatus(HttpStatus.CREATED)
 	public InviteResponseDTO inviteUser(@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@PathVariable("invite_code") String inviteCode, @RequestBody List<String> roles) {
-		return roomService.inviteUser(userPrincipal.getEmail(), inviteCode, roles);
+		return roomInviteService.inviteUser(userPrincipal.getEmail(), inviteCode, roles);
 	}
 
 	@GetMapping("/room/day")

--- a/src/main/java/com/travel/role/domain/room/service/ParticipantRoleReadService.java
+++ b/src/main/java/com/travel/role/domain/room/service/ParticipantRoleReadService.java
@@ -64,4 +64,10 @@ public class ParticipantRoleReadService {
 
 		return participantRoles;
 	}
+
+	public void validIsAdmin(User user, Room room) {
+		if (!participantRoleRepository.existsByUserAndRoomAndRoomRoleIn(user, room, List.of(RoomRole.ADMIN))) {
+			throw new UserHaveNotPrivilegeException();
+		}
+	}
 }

--- a/src/main/java/com/travel/role/domain/room/service/RoomInviteService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomInviteService.java
@@ -1,0 +1,107 @@
+package com.travel.role.domain.room.service;
+
+import static com.travel.role.global.util.Constants.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.travel.role.domain.room.dto.response.InviteResponseDTO;
+import com.travel.role.domain.room.entity.ParticipantRole;
+import com.travel.role.domain.room.entity.Room;
+import com.travel.role.domain.room.entity.RoomParticipant;
+import com.travel.role.domain.room.entity.RoomRole;
+import com.travel.role.domain.room.repository.ParticipantRoleRepository;
+import com.travel.role.domain.room.repository.RoomParticipantRepository;
+import com.travel.role.domain.user.entity.User;
+import com.travel.role.domain.user.service.UserReadService;
+import com.travel.role.global.exception.room.AlreadyExistInRoomException;
+import com.travel.role.global.exception.room.InvalidInviteCode;
+import com.travel.role.global.exception.room.UserHaveNotPrivilegeException;
+import com.travel.role.global.util.PasswordGenerator;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomInviteService {
+
+	private final UserReadService userReadService;
+	private final RoomReadService roomReadService;
+	private final ParticipantRoleReadService participantRoleReadService;
+
+	private final RoomParticipantRepository roomParticipantRepository;
+	private final ParticipantRoleRepository participantRoleRepository;
+
+	private final PasswordGenerator passwordGenerator;
+
+	@Transactional
+	public String makeInviteCode(String email, Long roomId) {
+		User user = userReadService.findUserByEmailOrElseThrow(email);
+		Room room = roomReadService.findRoomByIdOrElseThrow(roomId);
+
+		participantRoleReadService.validIsAdmin(user, room);
+
+		String inviteCode = passwordGenerator.generateRandomPassword(MAX_PASSWORD_LENGTH);
+		if (validateInviteCode(room)) {
+			inviteCode = passwordGenerator.generateRandomPassword(MAX_PASSWORD_LENGTH);
+			room.updateInviteCode(inviteCode, LocalDateTime.now());
+		}
+
+		return inviteCode;
+	}
+
+	@Transactional
+	public InviteResponseDTO inviteUser(String email, String inviteCode, List<String> roles) {
+		Room room = roomReadService.getRoomUsingInviteCode(inviteCode);
+		User user = userReadService.findUserByEmailOrElseThrow(email);
+
+		validateInviteRoom(email, room);
+		validateSelectRole(roles);
+
+		for (String role : roles) {
+			ParticipantRole participantRole = new ParticipantRole(null, RoomRole.valueOf(role), user, room);
+			participantRoleRepository.save(participantRole);
+		}
+
+		RoomParticipant roomParticipant = new RoomParticipant(null, LocalDateTime.now(), false, user, room);
+		roomParticipantRepository.save(roomParticipant);
+
+		return new InviteResponseDTO(room.getId());
+	}
+
+	public void checkRoomInviteCode(String email, String inviteCode) {
+		Room room = roomReadService.getRoomUsingInviteCode(inviteCode);
+
+		validateInviteRoom(email, room);
+	}
+
+	private boolean validateInviteCode(Room room) {
+		return room.getRoomInviteCode() == null || room.getRoomExpiredTime().plusDays(1L).isAfter(LocalDateTime.now());
+	}
+
+	private void validateInviteRoom(String email, Room room) {
+		if (!validateInviteCode(room)) {
+			throw new InvalidInviteCode();
+		}
+
+		if (roomParticipantRepository.existsUserInRoom(email, room.getId())) {
+			throw new AlreadyExistInRoomException();
+		}
+	}
+
+	private void validateSelectRole(List<String> roles) {
+		for (String role : roles) {
+			try {
+				if (RoomRole.valueOf(role) == RoomRole.ADMIN) {
+					throw new UserHaveNotPrivilegeException();
+				}
+			} catch (IllegalArgumentException e) {
+				throw new UserHaveNotPrivilegeException();
+			}
+		}
+	}
+}

--- a/src/main/java/com/travel/role/domain/room/service/RoomService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomService.java
@@ -1,6 +1,7 @@
 package com.travel.role.domain.room.service;
 
 import static com.travel.role.global.exception.dto.ExceptionMessage.*;
+import static com.travel.role.global.util.Constants.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -68,8 +69,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional
 public class RoomService {
-
-	private static final int MAX_PASSWORD_LENGTH = 20;
 
 	private final RoomRepository roomRepository;
 	private final UserReadService userReadService;

--- a/src/main/java/com/travel/role/domain/room/service/RoomService.java
+++ b/src/main/java/com/travel/role/domain/room/service/RoomService.java
@@ -53,7 +53,6 @@ import com.travel.role.domain.schedule.repository.ScheduleInfoRepository;
 import com.travel.role.domain.travelessential.service.TravelEssentialService;
 import com.travel.role.domain.user.entity.User;
 import com.travel.role.domain.user.service.UserReadService;
-import com.travel.role.global.exception.room.AdminIsOnlyOneException;
 import com.travel.role.global.exception.room.InvalidLocalDateException;
 import com.travel.role.global.exception.room.RoomNotUpdateAdminException;
 import com.travel.role.global.exception.room.UserHaveNotPrivilegeException;
@@ -270,21 +269,6 @@ public class RoomService {
 			result.put(email, data);
 		}
 		return result;
-	}
-
-	private List<String> validateUserRoleAndEmail(List<RoomRoleDTO> userRoles) {
-		List<String> admins = new ArrayList<>();
-
-		for (RoomRoleDTO userRole : userRoles) {
-			if (userRole.getRoles().contains(RoomRole.ADMIN))
-				admins.add(userRole.getEmail());
-		}
-
-		if (admins.size() >= 2) {
-			throw new AdminIsOnlyOneException();
-		}
-
-		return admins;
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/travel/role/global/util/Constants.java
+++ b/src/main/java/com/travel/role/global/util/Constants.java
@@ -6,4 +6,5 @@ public final class Constants {
 	public static final String REFRESH_TOKEN_NAME = "refreshToken";
 	public static final String OAUTH_LOGIN_FAILURE = "소셜 로그인에 실패하였습니다";
 	public static final String COOKIE_HEADER = "Set-Cookie";
+	public static final int MAX_PASSWORD_LENGTH = 20;
 }

--- a/src/test/java/com/travel/role/unit/room/service/RoomInviteServiceTest.java
+++ b/src/test/java/com/travel/role/unit/room/service/RoomInviteServiceTest.java
@@ -1,0 +1,160 @@
+package com.travel.role.unit.room.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.travel.role.domain.room.entity.Room;
+import com.travel.role.domain.room.repository.ParticipantRoleRepository;
+import com.travel.role.domain.room.repository.RoomParticipantRepository;
+import com.travel.role.domain.room.repository.RoomRepository;
+import com.travel.role.domain.room.service.ParticipantRoleReadService;
+import com.travel.role.domain.room.service.RoomInviteService;
+import com.travel.role.domain.room.service.RoomReadService;
+import com.travel.role.domain.user.entity.User;
+import com.travel.role.domain.user.service.UserReadService;
+import com.travel.role.global.auth.token.UserPrincipal;
+import com.travel.role.global.exception.room.InvalidInviteCode;
+import com.travel.role.global.exception.room.UserHaveNotPrivilegeException;
+import com.travel.role.global.util.PasswordGenerator;
+
+@ExtendWith(MockitoExtension.class)
+class RoomInviteServiceTest {
+
+	@InjectMocks
+	private RoomInviteService roomInviteService;
+
+	@Mock
+	private UserReadService userReadService;
+
+	@Mock
+	private RoomReadService roomReadService;
+
+	@Mock
+	private ParticipantRoleReadService participantRoleReadService;
+
+	@Mock
+	private RoomRepository roomRepository;
+	@Mock
+	private RoomParticipantRepository roomParticipantRepository;
+	@Mock
+	private ParticipantRoleRepository participantRoleRepository;
+
+	@Mock
+	private PasswordGenerator passwordGenerator;
+
+	@Test
+	void 해당_유저의_코드가_유효기간이_지나_재생성_해야하는_경우() {
+		//given
+		given(passwordGenerator.generateRandomPassword(20))
+			.willReturn("1234");
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
+			.willReturn(User.builder().build());
+		given(roomReadService.findRoomByIdOrElseThrow(anyLong()))
+			.willReturn(new Room(1L, "강릉으로떠나요", LocalDate.now(), LocalDate.now().plusDays(1L),
+				null, "강릉", "12", LocalDateTime.now().minusDays(1L).plusSeconds(1L)));
+		doNothing().when(participantRoleReadService)
+			.validIsAdmin(any(User.class), any(Room.class));
+
+		//when
+		String inviteCode = roomInviteService.makeInviteCode("haechan@naver.com", 1L);
+
+		//then
+		assertThat(inviteCode).isEqualTo("1234");
+	}
+
+	@Test
+	void 해당_유저의_코드를_처음_생성해_초대코드를_생성해야_하는_경우() {
+		//given
+		given(passwordGenerator.generateRandomPassword(20))
+			.willReturn("1234");
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
+			.willReturn(User.builder().build());
+		given(roomReadService.findRoomByIdOrElseThrow(anyLong()))
+			.willReturn(makeRoom());
+		doNothing().when(participantRoleReadService)
+			.validIsAdmin(any(User.class), any(Room.class));
+
+		//when
+		String inviteCode = roomInviteService.makeInviteCode("haechan@naver.com", 1L);
+
+		//then
+		assertThat(inviteCode).isEqualTo("1234");
+	}
+
+	@Test
+	void 방에_들어갔는데_코드가_만료된_경우() {
+		//given
+		given(roomReadService.getRoomUsingInviteCode(anyString()))
+			.willReturn(makeInvalidInviteDateRoom());
+
+		//when,then
+		assertThatThrownBy(() -> {
+			roomInviteService.checkRoomInviteCode("haechan@naver.com", "1234");
+		})
+			.isInstanceOf(InvalidInviteCode.class);
+	}
+
+	@Test
+	void 초대한_방_링크로_접속했을때_총무_역할을_선택한_경우() {
+		//given
+		given(roomReadService.getRoomUsingInviteCode(anyString()))
+			.willReturn(makeRoom());
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
+			.willReturn(makeUser());
+		given(roomParticipantRepository.existsUserInRoom(anyString(), anyLong()))
+			.willReturn(false);
+
+		//when, then
+		assertThatThrownBy(() -> {
+			roomInviteService.inviteUser("haechan@naver.com", "1234", List.of("ADMIN"));
+		})
+			.isInstanceOf(UserHaveNotPrivilegeException.class);
+	}
+
+	@Test
+	void 초대한_방_링크로_접속했을때_존재하지_않은_역할을_선택한_경우() {
+		//given
+		given(roomReadService.getRoomUsingInviteCode(anyString()))
+			.willReturn(makeRoom());
+		given(userReadService.findUserByEmailOrElseThrow(anyString()))
+			.willReturn(makeUser());
+		given(roomParticipantRepository.existsUserInRoom(anyString(), anyLong()))
+			.willReturn(false);
+
+		//when, then
+		assertThatThrownBy(() -> {
+			roomInviteService.inviteUser("haechan@naver.com", "1234", List.of("HAECHAN"));
+		})
+			.isInstanceOf(UserHaveNotPrivilegeException.class);
+	}
+
+	private static UserPrincipal makeUserPrincipal() {
+		return new UserPrincipal(1L, "haechan@naver.com", "1234", null);
+	}
+
+	private static Room makeRoom() {
+		return new Room(1L, "강릉으로떠나요", LocalDate.now(), LocalDate.now().plusDays(1L),
+			1L, "강릉", null, null);
+	}
+
+	private static Room makeInvalidInviteDateRoom() {
+		return new Room(1L, "강릉으로떠나요", LocalDate.now(), LocalDate.now().plusDays(1L),
+			1L, "강릉", "1234", LocalDateTime.now().minusDays(2L));
+	}
+
+	private static User makeUser() {
+		return new User(1L, "해찬", "haechan@naver.com", "1234", null, LocalDate.now());
+	}
+
+}

--- a/src/test/java/com/travel/role/unit/room/service/RoomInviteServiceTest.java
+++ b/src/test/java/com/travel/role/unit/room/service/RoomInviteServiceTest.java
@@ -15,15 +15,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.travel.role.domain.room.entity.Room;
-import com.travel.role.domain.room.repository.ParticipantRoleRepository;
 import com.travel.role.domain.room.repository.RoomParticipantRepository;
-import com.travel.role.domain.room.repository.RoomRepository;
 import com.travel.role.domain.room.service.ParticipantRoleReadService;
 import com.travel.role.domain.room.service.RoomInviteService;
 import com.travel.role.domain.room.service.RoomReadService;
 import com.travel.role.domain.user.entity.User;
 import com.travel.role.domain.user.service.UserReadService;
-import com.travel.role.global.auth.token.UserPrincipal;
 import com.travel.role.global.exception.room.InvalidInviteCode;
 import com.travel.role.global.exception.room.UserHaveNotPrivilegeException;
 import com.travel.role.global.util.PasswordGenerator;
@@ -44,11 +41,7 @@ class RoomInviteServiceTest {
 	private ParticipantRoleReadService participantRoleReadService;
 
 	@Mock
-	private RoomRepository roomRepository;
-	@Mock
 	private RoomParticipantRepository roomParticipantRepository;
-	@Mock
-	private ParticipantRoleRepository participantRoleRepository;
 
 	@Mock
 	private PasswordGenerator passwordGenerator;
@@ -137,10 +130,6 @@ class RoomInviteServiceTest {
 			roomInviteService.inviteUser("haechan@naver.com", "1234", List.of("HAECHAN"));
 		})
 			.isInstanceOf(UserHaveNotPrivilegeException.class);
-	}
-
-	private static UserPrincipal makeUserPrincipal() {
-		return new UserPrincipal(1L, "haechan@naver.com", "1234", null);
 	}
 
 	private static Room makeRoom() {


### PR DESCRIPTION
### 구현 목록
- RoomService가 너무 복잡해짐에 따라서 Invite를 하는 ㅋ드 분리 
- RoomService 분리에 따른 test코드 분리
- invite 코드가 기존과 같다면 재생성하는 코드 변경 (불필요한 db접근이라고 판단)
### 테스트 코드
<img width="317" alt="image" src="https://github.com/TravelRole/roleTravel-backend/assets/74089271/5f910342-7fc7-4721-83bc-efed37e7404c">
